### PR TITLE
Fix TypeError: sequence item 3: expected str instance, bytes found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ package_attributes = {
     'description': about['__summary__'],
     'entry_points': ENTRY_POINTS,
     'install_requires': INSTALL_REQUIRES,
-    'keywords': ' '.join(about['__keywords__']),
+    # This is a temporary hack because I'm not sure what encoding to use to decode when a bytes object is found in about['__keywords__'].
+    'keywords': ' '.join(kw for kw in about['__keywords__'] if type(kw) is not bytes),
     'license': about['__license__'],
     'long_description': LONG_DESCRIPTION,
     'name': about['__title__'],


### PR DESCRIPTION
```
$ pip install git+https://github.com/pojx/tox-pyenv-install.git
Building wheels for collected packages: tox-pyenv-install
  Building wheel for tox-pyenv-install (setup.py): started
  Building wheel for tox-pyenv-install (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-req-build-ep7yxr4w/setup.py", line 80, in <module>
          'keywords': ' '.join(about['__keywords__']),
      TypeError: sequence item 3: expected str instance, bytes found
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for tox-pyenv-install
```
https://gitlab.com/pythonpackagesalpine/python-extensions-alpine/-/jobs/2226742542

It appears that sometimes there are bytes objects in `__keywords__`. I am unsure how to properly decode them when that happens, but as a quick fix, we can skip over those.

The right solution is obviously to properly decode those keywords when they appear as bytes. I do not really understand `about[__keywords__]` and I'm not sure what gets put in there and how it might be encoded. I'm hoping you know more about this.