### PR TITLE
Allow tox --tox-pyenv-install-auto-install

### DIFF
--- a/tox_pyenv_install.py
+++ b/tox_pyenv_install.py
@@ -678,6 +678,7 @@ def _setup_auto_install(parser):
     )
     tox_pyenv_install_group.add_argument(
         '--tox-pyenv-install-auto-install', '-I',
+        action='store_true',
         dest=cli_dest,
         help=halp
     )


### PR DESCRIPTION
The README gives an example tox call as `tox --tox-pyenv-install-auto-install`. However, this does not currently work. Currently it must be invoked as `tox --tox-pyenv-install-auto-install True`.